### PR TITLE
Add required state option to Strategy

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -47,7 +47,8 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://medium.com/m/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://api.medium.com/v1/tokens';
   options.scope = options.scope || ["basicProfile", "listPublications", "publishPost"]
-
+  options.state = options.state || "keyboardcat" 
+  
   options.scope = options.scope.join(",")
 
   OAuth2Strategy.call(this, options, verify);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -20,7 +20,8 @@ var OAuth2Strategy = require('passport-oauth2')
  *   - `clientID`      your Medium application's client id
  *   - `clientSecret`  your Medium application's client secret
  *   - `callbackURL`   URL to which Medium will redirect the user after granting 
- *
+ *   - `state`         arbitrary text of your choosing, which Medium will repeat back to you to help you prevent request forgery.
+
  *
  * Examples:
  *
@@ -47,8 +48,9 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://medium.com/m/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://api.medium.com/v1/tokens';
   options.scope = options.scope || ["basicProfile", "listPublications", "publishPost"]
-  options.state = options.state || "keyboardcat" 
-  
+  if(!options.state) {
+    throw new Error("options.state should not be null or undefined. It is a required parameter.")
+  }
   options.scope = options.scope.join(",")
 
   OAuth2Strategy.call(this, options, verify);


### PR DESCRIPTION
According to the Medium API Docks the request must have a `state` parameter. I have added the state parameter option and a default state to the strategy. The library and authentication does not work without this.

source: https://github.com/Medium/medium-api-docs#21-browser-based-authentication